### PR TITLE
fix: 公式LINE登録ボタンのリンク切れを修正（our-people / ceo-message / contact-candidate）

### DIFF
--- a/docs/ceo-message/index.html
+++ b/docs/ceo-message/index.html
@@ -75,7 +75,7 @@
           <p class="text sd appear ceo-cta-line-title r11">公式LINEから無料キャリア面談予約</p>
           <p class="text sd appear ceo-cta-line-subtitle r12">公式LINEでは、コンサル転職必携資料をプレゼント中<br></p>
           <p class="text sd appear ceo-cta-line-items r13">・MBB内定時の職務経歴書<br>・ケース面接練習問題100選<br>・コンサル転職読むべき本30選<br>・ケース面接の考え方テキストブック</p>
-          <div class="sd appear ceo-cta-line-btn-wrap"><a href=" https://page.line.me/071ncncf" class="sd appear ceo-cta-line-btn-link">
+          <div class="sd appear ceo-cta-line-btn-wrap"><a href="https://line.me/R/ti/p/@071ncncf?from=page&searchId=071ncncf" class="sd appear ceo-cta-line-btn-link">
               <p class="text sd appear ceo-cta-line-btn-text r14">公式LINEに登録する</p><i aria-hidden="true" class="icon material-icons sd appear ceo-cta-line-btn-icon">arrow_forward</i>
             </a></div>
         </div>

--- a/docs/contact-candidate/index.html
+++ b/docs/contact-candidate/index.html
@@ -111,7 +111,7 @@
         <p class="text sd appear contact-cand-cta-line-title r20">無料キャリア面談は公式LINEからも申し込み可能</p>
         <p class="text sd appear contact-cand-cta-line-subtitle r21">公式LINEでは、コンサル転職必携資料をプレゼント中<br></p>
         <p class="text sd appear contact-cand-cta-line-items r22">・MBB内定時の職務経歴書<br>・ケース面接練習問題100選<br>・コンサル転職読むべき本30選<br>・ケース面接の考え方テキストブック</p>
-        <div class="sd appear contact-cand-cta-line-btn-wrap"><a href=" https://page.line.me/071ncncf" class="sd appear contact-cand-cta-line-btn-link">
+        <div class="sd appear contact-cand-cta-line-btn-wrap"><a href="https://line.me/R/ti/p/@071ncncf?from=page&searchId=071ncncf" class="sd appear contact-cand-cta-line-btn-link">
             <p class="text sd appear contact-cand-cta-line-btn-text r23">公式LINEに登録する</p><i aria-hidden="true" class="icon material-icons sd appear contact-cand-cta-line-btn-icon">arrow_forward</i>
           </a></div>
       </div>

--- a/docs/our-people/index.html
+++ b/docs/our-people/index.html
@@ -136,7 +136,7 @@
         <p class="text sd appear people-cta-title r28">公式LINEから無料キャリア面談予約</p>
         <p class="text sd appear people-cta-subtitle r29">公式LINEでは、コンサル転職必携資料をプレゼント中<br></p>
         <p class="text sd appear people-cta-details r30">・MBB内定時の職務経歴書<br>・ケース面接練習問題100選<br>・コンサル転職読むべき本30選<br>・ケース面接の考え方テキストブック</p>
-        <div class="sd appear people-cta-btn-wrap"><a href=" https://page.line.me/071ncncf" class="sd appear people-cta-btn">
+        <div class="sd appear people-cta-btn-wrap"><a href="https://line.me/R/ti/p/@071ncncf?from=page&searchId=071ncncf" class="sd appear people-cta-btn">
             <p class="text sd appear people-cta-btn-text r31">公式LINEに登録する</p><i aria-hidden="true" class="icon material-icons sd appear people-cta-btn-icon">arrow_forward</i>
           </a></div>
       </div>


### PR DESCRIPTION
## Summary

- `our-people` / `ceo-message` / `contact-candidate` の3ページで使用していた公式LINE登録ボタンのリンク切れを修正
- 旧 URL `https://page.line.me/071ncncf` → LINE 公式推奨の友だち追加リンク `https://line.me/R/ti/p/@071ncncf?from=page&searchId=071ncncf` に差し替え
- あわせて href 先頭に入っていた半角スペースも除去

## Closes

Closes #38

## Changes

- `docs/our-people/index.html:139` — `people-cta-btn` の href を差し替え
- `docs/ceo-message/index.html:78` — `ceo-cta-line-btn-link` の href を差し替え
- `docs/contact-candidate/index.html:114` — `contact-cand-cta-line-btn-link` の href を差し替え

## Test Plan

- [x] [UI] `/our-people/` で「公式LINEに登録する」ボタンの href が `https://line.me/R/ti/p/@071ncncf?from=page&searchId=071ncncf` になっていること
- [x] [UI] `/ceo-message/` で「公式LINEに登録する」ボタンの href が `https://line.me/R/ti/p/@071ncncf?from=page&searchId=071ncncf` になっていること
- [x] [UI] `/contact-candidate/` で「公式LINEに登録する」ボタンの href が `https://line.me/R/ti/p/@071ncncf?from=page&searchId=071ncncf` になっていること
- [ ] [UI][MANUAL] 上記3ページのボタンを実際にクリック → LINE 公式アカウント（`@071ncncf` / ステラキャリアーズ）の友だち追加画面に遷移する
- [x] [LOGIC] `grep -rn "page.line.me" docs/` の結果が 0 件であること
- [x] [BUILD] `npm run lint` がエラーなく完了すること

## Verification

- dev server (port 3010) で `curl` による href 値確認を3ページ実施。いずれも新URLが正しく出力されていることを確認済み。
- `[UI][MANUAL]` 項目（実機で友だち追加画面に遷移するか）はスマートフォンの LINE アプリが必要なため、マージ前にレビュアー側で実機確認をお願いします。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)