### PR TITLE
ステラコーチLPヒーロー見出しを明示改行に修正（#47）

### DIFF
--- a/docs/stellar-coach/index.html
+++ b/docs/stellar-coach/index.html
@@ -62,7 +62,7 @@
           <p class="coach-hero-service-name-ja">ステラコーチ</p>
         </div>
         <p class="coach-hero-kicker coach-fade-up">元マッキンゼーAIリーダー監修</p>
-        <h1 class="coach-hero-title coach-fade-up">本格AIケース面接対策、10回分を¥0で。</h1>
+        <h1 class="coach-hero-title coach-fade-up">本格AIケース面接対策<br>10回分を￥0で</h1>
         <p class="coach-hero-sub coach-fade-up">ステラコーチなら誰でも無料でケース面接の練習ができます。</p>
         <p class="coach-hero-note coach-fade-up">※本サービスは転職活動中の社会人を対象としています。大学生のかたはご利用いただけません。</p>
         <div class="coach-hero-cta coach-fade-up">


### PR DESCRIPTION
## Summary

ステラコーチLPのヒーロー見出しが自動折り返しでビューポート幅により意図しない位置で改行されていた問題を、`<br>` による明示改行に変更して2行表示で固定化した。

## Closes

Closes #47

## Changes

- `docs/stellar-coach/index.html:65` のヒーロー見出しを以下に変更:
  - 変更前: `本格AIケース面接対策、10回分を¥0で。`
  - 変更後: `本格AIケース面接対策<br>10回分を￥0で`
- 句読点「、」「。」を除去
- 「¥」（半角）→「￥」（全角）に統一
- CSS変更なし

## Test Plan

- [x] [UI] /stellar-coach/ のヒーロー見出しが「本格AIケース面接対策」「10回分を￥0で」の2行で表示されること
- [x] [UI] デスクトップ表示（1200px以上）で2行表示が維持されること
- [x] [UI] タブレット表示（840px以下）で2行表示が維持されること
- [x] [UI] モバイル表示（540px以下）で2行表示が維持され、文字が画面からはみ出さないこと
- [x] [UI] 句読点「、」「。」が表示されないこと
- [x] [UI] 「¥」（半角）ではなく「￥」（全角）で表示されること
- [x] [BUILD] npm run lint がエラーなく完了すること

## Verification

Playwrightで3ビューポートを検証。すべて `textContent="本格AIケース面接対策10回分を￥0で"` / `innerHTML` に `<br>` を含み、高さ/lineHeight が 2.0 ≒ 2行表示で水平オーバーフローなし。

| ビューポート | 幅 | 見出し高さ | font-size | line-height | 行数 | scrollWidth |
|---|---|---|---|---|---|---|
| Desktop | 1280px | 135.19px | 52px | 67.6px | 2行 | 1280px（=innerWidth） |
| Tablet | 800px | 104.00px | 40px | 52.0px | 2行 | 800px（=innerWidth） |
| Mobile | 375px | 72.78px | 28px | 36.4px | 2行 | 375px（=innerWidth） |

スクリーンショット: `.screenshots/issue-47/{desktop,tablet,mobile}.png`（gitignored）

`npm run lint` (htmlhint + stylelint) は正常終了。