### PR TITLE
ステラコーチLP有料プランの価値訴求を対人FB主役に再構成（#49）

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -19208,6 +19208,99 @@ a.text {
   margin-top: 2px;
 }
 
+/*
+ * --- Coach Plan Highlight ---
+ * 「含まれるもの」のうち、対人振り返りセッションを主役として強調表示する。
+ * AIケース問題などの学習教材は coach-plan-sub-list 側で控えめに見せる。
+ */
+.coach-plan-highlight {
+  display: block;
+  align-items: stretch;
+  border: 2px solid var(--coach-black);
+  border-radius: 6px;
+  padding: 1.75rem 1.5rem;
+  margin-bottom: 1.75rem;
+  background: var(--coach-gray-50);
+  text-align: center;
+}
+
+.coach-plan-highlight-label {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: var(--coach-white);
+  background: var(--coach-black);
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  margin-bottom: 1rem;
+}
+
+.coach-plan-highlight-title {
+  font-size: clamp(1.25rem, 3.2vw, 1.625rem);
+  font-weight: 800;
+  line-height: 1.45;
+  color: var(--coach-black);
+  margin: 0 0 0.5rem;
+}
+
+.coach-plan-highlight-meta {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--coach-black);
+  margin: 0 0 0.875rem;
+}
+
+.coach-plan-highlight-desc {
+  font-size: 0.9375rem;
+  line-height: 1.8;
+  color: var(--coach-gray-700);
+  margin: 0;
+  text-align: left;
+}
+
+/* --- Coach Plan Sub List (学習教材・カウンセリング) --- */
+.coach-plan-sub-lead {
+  font-size: 0.8125rem;
+  color: var(--coach-gray-600);
+  margin: 0 0 0.75rem;
+  align-self: flex-start;
+}
+
+.coach-plan-sub-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 3rem;
+  width: 100%;
+}
+
+.coach-plan-sub-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.625rem;
+  padding: 0.5rem 0;
+  font-size: 0.8125rem;
+  color: var(--coach-gray-600);
+  line-height: 1.6;
+}
+
+.coach-plan-sub-icon {
+  flex-shrink: 0;
+  margin-top: 3px;
+}
+
+/* レスポンシブ：540px 以下はハイライトの余白とフォントを 1 段詰める */
+@media (max-width: 540px) {
+  .coach-plan-highlight {
+    padding: 1.25rem 1rem;
+  }
+
+  .coach-plan-highlight-desc {
+    font-size: 0.875rem;
+    line-height: 1.75;
+  }
+}
+
 /* --- Coach Refund Box --- */
 .coach-plan-refund {
   margin-bottom: 3rem;

--- a/docs/stellar-coach/index.html
+++ b/docs/stellar-coach/index.html
@@ -263,21 +263,26 @@
             </div>
             <div class="coach-plan-content">
               <h3 class="coach-plan-subtitle">含まれるもの</h3>
-              <ul class="coach-plan-list">
+              <!-- メイン価値: 戦略ファーム出身者との対人振り返りセッション -->
+              <div class="coach-plan-highlight">
+                <span class="coach-plan-highlight-label">本プランの中核</span>
+                <h4 class="coach-plan-highlight-title">戦略ファーム出身者との<br>対人振り返りセッション</h4>
+                <p class="coach-plan-highlight-meta">全 4 回 × 各 50 分</p>
+                <p class="coach-plan-highlight-desc">あなたのケース回答を、戦略ファーム出身者が「思考プロセス」と「伝え方」の両面から直接フィードバック。AIだけでは届かない、現場の構造化と批評の感覚をマンツーマンでお渡しします。</p>
+              </div>
+
+              <p class="coach-plan-sub-lead">対人セッションを最大限活かすため、以下も含まれます。</p>
+              <ul class="coach-plan-sub-list">
                 <li>
-                  <svg class="coach-check-icon" width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true"><circle cx="10" cy="10" r="10" fill="#0a0a0a"/><path d="M6 10 L9 13 L14 7" stroke="#fff" stroke-width="2" fill="none"/></svg>
+                  <svg class="coach-plan-sub-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="8" fill="#9ca3af"/><path d="M5 8 L7 10 L11 6" stroke="#fff" stroke-width="1.6" fill="none"/></svg>
                   AIケース面接問題 30題（何度でも解き直し可能）
                 </li>
                 <li>
-                  <svg class="coach-check-icon" width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true"><circle cx="10" cy="10" r="10" fill="#0a0a0a"/><path d="M6 10 L9 13 L14 7" stroke="#fff" stroke-width="2" fill="none"/></svg>
+                  <svg class="coach-plan-sub-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="8" fill="#9ca3af"/><path d="M5 8 L7 10 L11 6" stroke="#fff" stroke-width="1.6" fill="none"/></svg>
                   各問題の詳細な解説書 30題分
                 </li>
                 <li>
-                  <svg class="coach-check-icon" width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true"><circle cx="10" cy="10" r="10" fill="#0a0a0a"/><path d="M6 10 L9 13 L14 7" stroke="#fff" stroke-width="2" fill="none"/></svg>
-                  戦略ファーム出身者との対人振り返りセッション（4回×50分）
-                </li>
-                <li>
-                  <svg class="coach-check-icon" width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true"><circle cx="10" cy="10" r="10" fill="#0a0a0a"/><path d="M6 10 L9 13 L14 7" stroke="#fff" stroke-width="2" fill="none"/></svg>
+                  <svg class="coach-plan-sub-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="8" fill="#9ca3af"/><path d="M5 8 L7 10 L11 6" stroke="#fff" stroke-width="1.6" fill="none"/></svg>
                   戦略ファーム内定に向けたキャリアカウンセリング
                 </li>
               </ul>


### PR DESCRIPTION
## Summary

ステラコーチLPの有料プラン「含まれるもの」を、フラットな 4 項目リストから「対人振り返りセッションを主役にした 2 層構造」に再構成。¥78,000 が AI サービスへの対価に見える誤読を防ぎ、戦略ファーム出身者によるマンツーマン FB が本プランの中核であることを視覚的に明示する。

## Closes

Closes #49

## Changes

- **HTML** (`docs/stellar-coach/index.html`): 対人セッションを `.coach-plan-highlight` カードとして「本プランの中核」バッジ + 大きめタイトル + サブコピー付きで配置。AIケース問題 / 解説書 / キャリアカウンセリングは `.coach-plan-sub-list` で控えめに併記。サブリスト直前に「対人セッションを最大限活かすため、以下も含まれます。」のリードを追加
- **CSS** (`docs/assets/css/style.css`): `.coach-plan-highlight`（枠線 + `--coach-gray-50` 背景 + `clamp(1.25rem, 3.2vw, 1.625rem)` タイトル）と `.coach-plan-sub-list`（0.8125rem グレー基調 + 16px チェックアイコン）を新規追加。540px 以下で padding / フォントを 1 段詰めるメディアクエリも併設

## Test Plan

> 注: このセクションは PR 作成時点での Issue #49 `## 受け入れ条件` のスナップショット。verification の source-of-truth は Issue 側にあり、`/uat` は常に Issue を authoritative として読む。

- [x] [UI] `/stellar-coach` `#coach-plans` セクションで「戦略ファーム出身者との対人振り返りセッション」が、他の含有物よりも明らかに大きい/目立つビジュアルで先頭に表示されること
- [x] [UI] 「AIケース面接問題 30題」「解説書 30題分」「キャリアカウンセリング」が、対人セッションの下に、より小さく控えめな見せ方で並ぶこと
- [x] [UI] 540px 以下の幅でもハイライトが破綻せず、対人セッションが視覚的に最強調を維持していること
- [x] [UI] ¥78,000 / 税込 ¥85,800 / 内定返金保証 / 教材デモグリッドなど既存要素の表示崩れがないこと
- [x] [BUILD] `npm run lint` が通ること（htmlhint + stylelint）
- [ ] [MANUAL] 価格表示を見たときに「対人セッションの対価」として読める情報設計になっていること（福本さん/村木さんレビュー想定）

## Verification

### [UI] デスクトップ（1280×900）

`#coach-plans` セクション全体。「本プランの中核」バッジ → 大きな見出し → サブコピーで対人セッションが主役化され、AI問題/解説書/キャリアカウンセリングは小さいグレー文字 + 小チェックで控えめに併記されている。¥78,000・内定返金保証・教材デモグリッドは既存通り。

![01-PASS-desktop-plans-section.png](https://github.com/stellar-careers/stellar-careers.github.io/releases/download/uat-evidence/tackle-49-coach-plan-restructure-20260525-113448-01-PASS-desktop-plans-section.png)

### [UI] モバイル（375×800）

横スクロール発生なし（`scrollWidth === clientWidth === 375`）。ハイライトカードの padding / フォントが 1 段縮み、レスポンシブで破綻なし。階層関係は維持。

![02-PASS-mobile-plans-section.png](https://github.com/stellar-careers/stellar-careers.github.io/releases/download/uat-evidence/tackle-49-coach-plan-restructure-20260525-113448-02-PASS-mobile-plans-section.png)

### [BUILD]

`npm run lint`（htmlhint + stylelint）通過。htmlhint は 61 ファイル scan で 0 errors。

### [MANUAL]

価格表示の情報設計レビューは福本さん / 村木さんの主観判断に委ねる。文言案（中核説明文）はレビューで擦り合わせ可能な前提で投入済み。