### PR TITLE
preview deploy に concurrency group を追加して race condition を防ぐ

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,6 +4,14 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, closed]
 
+# 同じ PR の preview deploy / cleanup を直列化する。
+# Copilot が短時間に複数イベント (synchronize / ready_for_review 等) を
+# 発火させると複数 job が同時に homepage-preview.git#main へ push しようとして
+# remote rejected (cannot lock ref) で fail する race condition を防ぐ。
+concurrency:
+  group: preview-deploy-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   deploy-preview:
     # Skip: closed PRs, and newly opened draft PRs (e.g. GitHub Copilot creates draft first)


### PR DESCRIPTION
## Summary

PR #53 で観測した preview deploy の race condition (`remote rejected: cannot lock ref`) を再発防止する。

## 背景

PR #53 では同一 PR に対して `synchronize` 等のイベントが短時間に2回発火し、2つの deploy job が並列に走った結果、片方が `homepage-preview.git#main` への push 時に remote rejected で失敗した。

実際の失敗 run: https://github.com/stellar-careers/stellar-careers.github.io/actions/runs/26546676779

```
! [remote rejected] main -> main (cannot lock ref 'refs/heads/main':
  is at 956cd1a1... but expected 0b36bd43...)
```

## 修正内容

workflow 全体に `concurrency` を追加:

```yaml
concurrency:
  group: preview-deploy-pr-${{ github.event.pull_request.number }}
  cancel-in-progress: true
```

- group key を PR 番号にして同じ PR の deploy / cleanup を直列化
- `cancel-in-progress: true` で新しいイベントが古い実行をキャンセル
  → 古い commit に対する deploy が走り続けるのを防ぎ、最新状態が反映されるようにする

## トレードオフ

- 異なる PR 同士の push 競合は引き続き理論的に発生し得る (この PR の対象外)。観測されたら fetch+rebase リトライ等で対処する。

## Test plan

- [ ] 本 PR の preview deploy が成功すること (concurrency 設定自体の動作確認)
- [ ] 次回 Copilot による Issue 起票時、短時間連続イベントでも remote rejected が発生しないこと