### PR TITLE
chore: AI時代のコンサルファーム選び記事を各ファーム情報カテゴリへ移動

### DIFF
--- a/docs/insight-firm/index.html
+++ b/docs/insight-firm/index.html
@@ -65,7 +65,11 @@
       <section id="feature-1" class="sd appear insight-cat-section">
         <div class="sd appear insight-cat-tabs"><a href="../insight" class="button sd appear insight-cat-tab-btn"><span class="text link sd appear insight-cat-tab-text">すべて</span></a><a href="../insight-case" class="button sd appear insight-cat-tab-btn"><span class="text link sd appear insight-cat-tab-text r9">転職体験記</span></a><a href="../insight-interview" class="button sd appear insight-cat-tab-btn-alt1"><span class="text link sd appear insight-cat-tab-text-alt1 r10">面接対策</span></a><a href="../insight-work" class="button sd appear insight-cat-tab-btn-alt2"><span class="text link sd appear insight-cat-tab-text-alt2 r11">仕事術</span></a><a href="../insight-firm" class="button sd appear insight-tab-active insight-cat-tab-btn"><span class="text link sd appear insight-cat-tab-text">各ファーム情報</span></a></div>
         <div class="sd appear insight-cat-articles">
-          <ul class="sd appear insight-cat-grid"></ul>
+          <ul class="sd appear insight-cat-grid"><a href="../insight/50buy5DB" class="link sd appear insight-cat-card">
+              <div class="sd appear insight-cat-card-body">
+                <h3 class="text sd appear insight-cat-card-title">【AI時代のコンサルファームの選び方（1/4）】 なぜコンサル業界はAI活用で先行するのか—事業会社との「取り組みの差」が生まれる理由—</h3>
+              </div><img class="sd insight-cat-card-img" alt="" src="../assets/images/insight_ai_consulting_gap_middle.webp">
+            </a></ul>
         </div>
       </section>
       <footer id="footer-2" class="sd appear insight-cat-footer">

--- a/docs/insight-work/index.html
+++ b/docs/insight-work/index.html
@@ -65,11 +65,7 @@
       <section id="feature-1" class="sd appear insight-cat-section">
         <div class="sd appear insight-cat-tabs"><a href="../insight" class="button sd appear insight-cat-tab-btn"><span class="text link sd appear insight-cat-tab-text">すべて</span></a><a href="../insight-case" class="button sd appear insight-cat-tab-btn"><span class="text link sd appear insight-cat-tab-text r9">転職体験記</span></a><a href="../insight-interview" class="button sd appear insight-cat-tab-btn-alt1"><span class="text link sd appear insight-cat-tab-text-alt1 r10">面接対策</span></a><a href="../insight-work" class="button sd appear insight-tab-active insight-cat-tab-btn-alt2"><span class="text link sd appear insight-cat-tab-text-alt2 r11">仕事術</span></a><a href="../insight-firm" class="button sd appear insight-cat-tab-btn"><span class="text link sd appear insight-cat-tab-text">各ファーム情報</span></a></div>
         <div class="sd appear insight-cat-articles">
-          <ul class="sd appear insight-cat-grid"><a href="../insight/50buy5DB" class="link sd appear insight-cat-card">
-              <div class="sd appear insight-cat-card-body">
-                <h3 class="text sd appear insight-cat-card-title">【AI時代のコンサルファームの選び方（1/4）】 なぜコンサル業界はAI活用で先行するのか—事業会社との「取り組みの差」が生まれる理由—</h3>
-              </div><img class="sd insight-cat-card-img" alt="" src="../assets/images/insight_ai_consulting_gap_middle.webp">
-            </a><a href="../insight/Y7mK2pLs" class="link sd appear insight-cat-card">
+          <ul class="sd appear insight-cat-grid"><a href="../insight/Y7mK2pLs" class="link sd appear insight-cat-card">
               <div class="sd appear insight-cat-card-body">
                 <h3 class="text sd appear insight-cat-card-title">「1ヶ月で200件インタビュー」元BCGが語る、トップファームの泥臭すぎるリアルと1日のスケジュール</h3>
               </div><img class="sd insight-cat-card-img" alt="" src="../assets/images/insight_bcg_200interviews_schedule_middle.webp">


### PR DESCRIPTION
## Summary

記事 `50buy5DB`（「【AI時代のコンサルファームの選び方（1/4）】…」）を「仕事術（insight-work）」から「各ファーム情報（insight-firm）」カテゴリ一覧へ移設する。

## Closes

Closes #61

## Changes

- `docs/insight-work/index.html` — 当該記事カードを削除
- `docs/insight-firm/index.html` — 当該記事カードを追加（空グリッドへ挿入）
- 全記事一覧 `docs/insight/index.html`・ホームカルーセル `docs/index.html` は変更なし

## Test Plan

> 注: このセクションは PR 作成時点での Issue #61 `## 受け入れ条件` のスナップショット。

- [x] [UI] `/insight-firm/` に「【AI時代のコンサルファームの選び方（1/4）】…」のカードが表示される
- [x] [UI] `/insight-work/` に同記事のカードが表示されない
- [x] [UI] `/insight/`（全記事一覧）に同記事のカードが引き続き表示される
- [x] [UI] 各カードのリンク先が `../insight/50buy5DB` で、記事ページが正しく開く
- [x] [BUILD] `npx htmlhint docs/insight-firm/index.html docs/insight-work/index.html docs/insight/index.html` がエラーなく通る

## Verification

検証は worktree 内で配信した実 HTML に対して実施（Playwright 未導入のため DOM レベルで確認・スクショなし）:

- [UI] `/insight-firm/`: `50buy5DB` カード=1・タイトル出現=1 ✅
- [UI] `/insight-work/`: `50buy5DB` カード=0・タイトル出現=0 ✅
- [UI] `/insight/`（全記事一覧）: `50buy5DB` カード=1（維持）✅
- [UI] `/insight/50buy5DB/`（記事本体）: HTTP 200 ✅
- [BUILD] htmlhint: Scanned 3 files, no errors found ✅