### PR TITLE
Slack通知を Block Kit でユーザフレンドリーにする（受付・公開完了）

### DIFF
--- a/.github/workflows/notify-deploy.yml
+++ b/.github/workflows/notify-deploy.yml
@@ -15,12 +15,45 @@ jobs:
         id: commit
         run: echo "message=$(git log --no-merges --format=%s -1)" >> "$GITHUB_OUTPUT"
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2
+        uses: actions/github-script@v7
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_USER_OAUTH_TOKEN }}
+          # コミットメッセージ（準信頼入力）はペイロード文字列に直接展開せず、env 経由で
+          # JS 変数として安全に扱う（YAML 破壊・ペイロード注入の回避）。
+          COMMIT_MSG: ${{ steps.commit.outputs.message }}
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_USER_OAUTH_TOKEN }}
-          payload: |
-            channel: "C09KJ7UJ5HQ"
-            text: "ホームページ更新完了。直近の変更は「${{ steps.commit.outputs.message }}」です！ 確認は<https://stellar-careers.com/|こちら> ;)"
-            unfurl_links: false
-            unfurl_media: false
+          script: |
+            const esc = s => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+            const msg = process.env.COMMIT_MSG || '';
+            const site = 'https://stellar-careers.com/';
+
+            const text = `🚀 ホームページを更新しました：${msg}`;
+            const blocks = [
+              { type: 'header', text: { type: 'plain_text', text: '🚀 本番サイトを更新しました', emoji: true } },
+              { type: 'section', text: { type: 'mrkdwn', text: `*直近の変更*\n${esc(msg)}` } },
+              { type: 'context', elements: [
+                { type: 'mrkdwn', text: '✅ 公開が完了しました。ご対応ありがとうございました！ ;)' },
+              ]},
+              { type: 'actions', elements: [
+                { type: 'button', text: { type: 'plain_text', text: '🌐 サイトを見る', emoji: true }, url: site, style: 'primary' },
+              ]},
+            ];
+
+            const res = await fetch('https://slack.com/api/chat.postMessage', {
+              method: 'POST',
+              headers: {
+                'Authorization': `Bearer ${process.env.SLACK_BOT_TOKEN}`,
+                'Content-Type': 'application/json; charset=utf-8',
+              },
+              body: JSON.stringify({
+                channel: 'C09KJ7UJ5HQ',
+                text,
+                blocks,
+                unfurl_links: false,
+                unfurl_media: false,
+              }),
+            });
+            const data = await res.json();
+            if (!data.ok) {
+              core.setFailed(`Slack API error: ${data.error}`);
+            }

--- a/.github/workflows/notify-issue.yml
+++ b/.github/workflows/notify-issue.yml
@@ -25,10 +25,27 @@ jobs:
         with:
           script: |
             const issue = context.payload.issue;
-            const text =
-              `新しい記事の追加依頼が届きました📝（Issue #${issue.number}）` +
-              `タイトルは「${issue.title}」です！ 開発側で順次対応します。` +
-              `内容は<${issue.html_url}|こちら> ;)`;
+            // Slack mrkdwn 用に最小限のエスケープ（タイトルに < & > が含まれても壊れないように）
+            const esc = s => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+            const labels = (issue.labels || []).map(l => l.name);
+            const kind = labels.includes('blog') ? 'ブログ記事' : 'Insight記事';
+
+            const text = `📝 新しい${kind}の追加依頼（Issue #${issue.number}）：${issue.title}`;
+            const blocks = [
+              { type: 'header', text: { type: 'plain_text', text: '📝 新しい記事の追加依頼', emoji: true } },
+              { type: 'section', fields: [
+                { type: 'mrkdwn', text: `*種別*\n${kind}` },
+                { type: 'mrkdwn', text: `*Issue*\n<${issue.html_url}|#${issue.number}>` },
+              ]},
+              { type: 'section', text: { type: 'mrkdwn', text: `*タイトル*\n${esc(issue.title)}` } },
+              { type: 'context', elements: [
+                { type: 'mrkdwn', text: '🤖 開発側（Copilot）が自動で対応を始めます。記事の準備ができたらプレビューのお知らせを送りますね ;)' },
+              ]},
+              { type: 'actions', elements: [
+                { type: 'button', text: { type: 'plain_text', text: '📋 Issueを開く', emoji: true }, url: issue.html_url },
+              ]},
+            ];
+
             const res = await fetch('https://slack.com/api/chat.postMessage', {
               method: 'POST',
               headers: {
@@ -38,6 +55,7 @@ jobs:
               body: JSON.stringify({
                 channel: 'C09KJ7UJ5HQ',
                 text,
+                blocks,
                 unfurl_links: false,
                 unfurl_media: false,
               }),


### PR DESCRIPTION
## Summary

記事公開フローの Slack 通知を **Block Kit** で構造化し、見出し・情報・CTAボタンを整理してユーザフレンドリーにします。本PRは本リポジトリの2通知（**①受付** / **③公開完了**）が対象。**②プレビュー＆承認依頼**（`homepage-preview` リポジトリの `notify-preview.yml`）は別PRで対応します。

## Changes

- `notify-issue.yml`（①受付）— Block Kit 化
  - ヘッダ「📝 新しい記事の追加依頼」/ 種別（Insight記事 or ブログ記事）・Issueリンク・タイトル / 「📋 Issueを開く」ボタン
- `notify-deploy.yml`（③公開完了）— Block Kit 化 + 実装移行
  - ヘッダ「🚀 本番サイトを更新しました」/ 直近の変更 / 「🌐 サイトを見る」ボタン
  - `slackapi/slack-github-action` → `github-script` + `fetch` に統一
  - **セキュリティ修正**: コミットメッセージをペイロード文字列に `${{ }}` 直接展開していたのを、`env:` 経由の JS 変数に変更（YAML破壊・注入の回避）
- タイトル/コミットメッセージは Slack mrkdwn 向けに `< & >` をエスケープ

## Test Plan

- [ ] [MANUAL] 記事ラベル付き Issue 起票 → ①が Block Kit で届き「Issueを開く」が機能する
- [ ] [MANUAL] 本番 Pages デプロイ完了 → ③が Block Kit で届き「サイトを見る」が機能する
- [ ] [MANUAL] タイトルに `<` `&` を含む記事でレイアウトが崩れない