### PR TITLE
fix: 記事Issue起票時のSlack受付通知の二重送信を解消

### DIFF
--- a/.github/workflows/assign-copilot.yml
+++ b/.github/workflows/assign-copilot.yml
@@ -14,14 +14,17 @@ name: Auto-assign Copilot to Article Issues
 # 未設定の場合は GITHUB_TOKEN にフォールバックするが、その場合アサインはスキップされる。
 on:
   issues:
-    types: [opened, labeled]
+    types: [labeled]
 
 jobs:
   assign:
     runs-on: ubuntu-latest
+    # notify-issue.yml と同じ理由で labeled のみをトリガーとする
+    # （テンプレ起票時の opened + labeled 二重発火防止、Issue #69 参照）。
+    # replaceActorsForAssignable は冪等だが、無駄な二重 run を抑えるため同一修正を適用。
     if: >-
-      contains(github.event.issue.labels.*.name, 'insight記事') ||
-      contains(github.event.issue.labels.*.name, 'blog')
+      github.event.label.name == 'insight記事' ||
+      github.event.label.name == 'blog'
     permissions:
       issues: write
     steps:

--- a/.github/workflows/notify-issue.yml
+++ b/.github/workflows/notify-issue.yml
@@ -4,17 +4,19 @@ name: Notify Slack on Article Issue
 # エンジニア向けの Issue は通知しない（ラベルで絞り込み）。
 on:
   issues:
-    types: [opened, labeled]
+    types: [labeled]
 
 jobs:
   notify:
     runs-on: ubuntu-latest
-    # 記事ラベルが付いている Issue のみ通知。
-    # labeled イベントでも発火するので、テンプレでラベルが付かず後から手動で
-    # 付けた場合もカバーできる。
+    # 今回追加されたラベルが記事ラベルの場合のみ通知する。
+    # issue.labels 全体ではなく event.label（今回追加されたラベル単体）を見ることで、
+    # テンプレート起票時に opened + labeled が同時発火しても通知が1回に抑えられる
+    # （opened を外した理由。二重通知の経緯は Issue #69 参照）。
+    # ラベル無しで起票し後から手動付与する経路も labeled で1回通知される。
     if: >-
-      contains(github.event.issue.labels.*.name, 'insight記事') ||
-      contains(github.event.issue.labels.*.name, 'blog')
+      github.event.label.name == 'insight記事' ||
+      github.event.label.name == 'blog'
     steps:
       # Issue タイトルなどの信頼できない入力を ${{ }} で展開すると YAML が壊れたり
       # ペイロード注入される恐れがあるため、context.payload から JS 変数として安全に扱う。


### PR DESCRIPTION
Closes #69

## 背景

2026-06-12、記事追加 Issue（#67）をテンプレートから1回起票しただけで、Slack の受付通知（ヤタガラスちゃん）が同一内容で2件同時投稿された。依頼者（Hina さん）が「追加したのは1回のみです」と釈明する事態になり、Slack チャンネルの閲覧者が「依頼が二重登録されたのでは」と不安になる UX 上の問題が発生した。

根本原因は `notify-issue.yml` のトリガーが `[opened, labeled]` で、かつ発火条件が `issue.labels` 全体の `contains` チェックだったこと。Issue フォームテンプレートには `labels: ["insight記事"]` / `labels: ["blog"]` が設定されているため、GitHub は起票時に **`opened` と `labeled` を同時発火**する。どちらのペイロードでも `issue.labels` にラベルが含まれるため、両 run が `if` を通過して Slack 投稿が2回実行されていた。

## 目的

記事 Issue を1回起票したとき、Slack 受付通知がちょうど1件だけ投稿されるようにする。依頼側（Hina さん・Misaki さん）が通知を信頼でき、運用側（Hiromu）が釈明・調査をしなくて済む状態にする。

## 方針

`opened` イベントを削除し `labeled` のみをトリガーとすることで、テンプレート起票時の二重発火経路を断つ。さらに `if` 条件を `issue.labels` 全体の `contains` から `event.label.name`（今回追加されたラベル単体）の等値比較に変更する。これにより、テンプレート起票（`opened` + `labeled` 同時発火）でも `labeled` の1イベントだけが通知を発生させる。ラベル無し起票後の手動ラベル付与経路（`labeled` 発火）も引き続き1回通知される。

`assign-copilot.yml` も同じ `[opened, labeled]` + `issue.labels` パターンを持つ。こちらの `replaceActorsForAssignable` は冪等のため実害はなかったが、無駄な二重 run を抑えるために同一修正を適用して整合させた。

<details>
<summary>採用案と代替案</summary>

| 案 | 内容 | 採否 |
|---|---|---|
| A（採用） | `types: [labeled]` + `event.label.name == ...` | 採用。イベント単体で完結し、冪等性も問題なし |
| B | `types: [opened, labeled]` + `if` に `github.event_name` 分岐 | 条件が複雑になり可読性低下。却下 |
| C | `types: [opened]` のみ | ラベル無し起票→手動付与の救済経路が消える。却下 |

</details>

## 設計

| ファイル | 変更内容 | AC |
|---|---|---|
| `.github/workflows/notify-issue.yml` | `types: [opened, labeled]` → `types: [labeled]` | AC-1, AC-2, AC-4 |
| `.github/workflows/notify-issue.yml` | `if` 条件を `event.label.name ==` に変更、コメント更新 | AC-1, AC-2, AC-4 |
| `.github/workflows/assign-copilot.yml` | `types: [opened, labeled]` → `types: [labeled]` | AC-3 |
| `.github/workflows/assign-copilot.yml` | `if` 条件を `event.label.name ==` に変更、コメント追加 | AC-3 |

## 受入条件

> `issues:` イベントの workflow は default branch 版が実行されるため、本 PR の修正は merge 後でないと実機検証できない。AC-1〜4 は merge 後にテスト Issue で検証する（Slack 本番チャンネルへの通知が発生する点に注意）。

- [ ] AC-1 [LOGIC][SIDE-EFFECT][MUTATING] Insight記事テンプレートからテスト Issue を起票 → `notify-issue.yml` の run がちょうど1回実行され、Slack 通知が1件だけ届く
- [ ] AC-2 [LOGIC][SIDE-EFFECT][MUTATING] ラベル無しでテスト Issue を起票（この時点で通知0件）→ 手動で `insight記事` ラベルを付与 → 通知が1件届く
- [ ] AC-3 [LOGIC] AC-1 のテスト Issue 起票時、`assign-copilot.yml` の run も1回のみであること
- [ ] AC-4 [LOGIC] テスト Issue に記事ラベル以外（例: `bug`）を追加しても `notify-issue.yml` が発火しない（run が増えない）こと

## 評価観点

- `event.label.name` は `labeled` イベントにしか存在しない。`opened` が残っていた場合、`event.label` は `null` になり `if` 条件が `false` になるため二重発火は起きないが、`opened` を残す意味もない。今回の `types: [labeled]` 単独への変更で十分か確認を。
- 将来テンプレートに `labels:` が設定されなくなった（または新しいラベル名が増えた）場合、`event.label.name` の等値比較で漏れが生じる。テンプレート追加・ラベル変更時はこの `if` 条件を同時に更新する必要がある。

## 発見

- **merge 前実機検証が構造的に不可能**: `issues:` イベントの workflow は default branch（`main`）版が実行される仕様のため、この PR がマージされるまで修正後の動作を本物のイベントで確認できない。静的 YAML 構文確認（`python3 -c "import yaml ..."` → ok）は実施済みだが、動作確認は merge 後のテスト Issue 起票で行う必要がある。
- **将来テンプレートに `labels:` が無い場合は通知されない**: `event.label.name` 判定に変更したことで、ラベル無し起票後に手動でラベルを付与する経路は維持されるが、テンプレートから `labels:` が消えた場合は `labeled` イベントが発火しなくなるため通知が来ない。テンプレート追加・修正時のチェック事項として認識が必要。
