### PR TITLE
fix: Copilot自動アサインのGraphQLクエリ構文エラーを修正

### DIFF
--- a/.github/workflows/assign-copilot.yml
+++ b/.github/workflows/assign-copilot.yml
@@ -61,7 +61,7 @@ jobs:
                 node(id: $id) {
                   ... on Issue {
                     assignedActors(first: 20) {
-                      nodes { login ... on User { id } ... on Bot { id } }
+                      nodes { ... on User { id login } ... on Bot { id login } }
                     }
                   }
                 }


### PR DESCRIPTION
Closes #71

## 背景

記事ラベル（`insight記事` / `blog`）付き Issue の起票時に Copilot coding agent を自動アサインする `assign-copilot.yml` が、アサイン処理に到達する前の冪等性チェック用 GraphQL クエリで失敗していた。Issue #67（2026-06-12 起票）の run `27400688868` / `27400688916` が両方 failure となり、Copilot を手動アサインで救済した経緯がある。

エラー内容:
```
GraphqlResponseError: Selections can't be made directly on unions (see selections on Assignee)
```

運用側（Hiromu）は記事 Issue が起票されるたびに Copilot を手動アサインする必要があり、Slack 受付通知の「Copilot が自動で対応を始めます」という案内と実態が乖離していた。

## 目的

記事 Issue 起票時の Copilot 自動アサインを人手なしで完全に機能させる。運用側（Hiromu）の手動アサイン作業が不要になり、依頼側（Hina さん・Misaki さん）は起票から記事作成開始までが完全自動になる。

## 方針

根本原因は GraphQL の union 型の仕様違反。`assignedActors.nodes` の型は union 型 `Assignee` であり、union 型には共通フィールド（`login` を含む）でも直接フィールド選択ができない。`... on TypeName { field }` の inline fragment 構文が必須。

変更は **1行のみ**。既存の冪等ガード・mutation・`suggestedActors` クエリはすべて合法な構文であり、触らない。

PAT（`COPILOT_ASSIGN_TOKEN`）の認証・権限は機能していることを run ログで確認済み（`suggestedActors` クエリは通過し `copilot-swe-agent` を発見済み）。残っていたブロッカーはこの構文バグ1点のみ。

## 設計

| ファイル | 変更前 | 変更後 | AC |
|---------|--------|--------|-----|
| `.github/workflows/assign-copilot.yml:64` | `nodes { login ... on User { id } ... on Bot { id } }` | `nodes { ... on User { id login } ... on Bot { id login } }` | AC-1, AC-2, AC-3 |

## 受入条件

> `issues:` イベントの workflow は default branch 版が実行されるため、AC-2/AC-3 は merge 後（次の実運用の記事 Issue 起票）で検証する。

- [x] AC-1 [LOGIC] 修正後のクエリを `gh api graphql` で実 Issue の node に対して実行 → スキーマエラーなく `assignedActors` の id/login が返る

  **evidence** （Issue #67 の node に対して実行）:
  ```bash
  NODE_ID=$(gh issue view 67 --repo stellar-careers/stellar-careers.github.io --json id --jq .id)
  gh api graphql \
    -f query='query($id: ID!) { node(id: $id) { ... on Issue { assignedActors(first: 20) { nodes { ... on User { id login } ... on Bot { id login } } } } } }' \
    -f id="$NODE_ID"
  ```
  返却 JSON:
  ```json
  {"data":{"node":{"assignedActors":{"nodes":[{"id":"MDQ6VXNlcjkzMTU1NA==","login":"otiai10"},{"id":"BOT_kgDOC9w8XQ","login":"copilot-swe-agent"}]}}}}
  ```
  スキーマエラーなし、User（otiai10）と Bot（copilot-swe-agent）の id/login が正常取得できた。

- [ ] AC-2 [LOGIC][MUTATING][SIDE-EFFECT] merge 後、記事ラベル付き Issue の起票（次の実運用起票で可）→ `assign-copilot.yml` の run が success し、Issue の assignees に Copilot が自動付与される（Copilot の記事作成・プレビュー通知が後続で発生する点に注意）

- [ ] AC-3 [LOGIC] AC-2 と同じ Issue で run が再実行されても「既にアサイン済み」で正常スキップされる（冪等ガードの動作確認）

## 評価観点

- `... on Bot { id login }` で `copilot-swe-agent` の `login` が返ることは AC-1 の evidence で確認済み。冪等ガード `current.some(a => a.login === 'copilot-swe-agent')` と id 集合 `a.id` は修正後のレスポンス形でそのまま機能する想定だが、実運用（AC-2）での確認を推奨
- `suggestedActors` クエリの `nodes { login __typename ... on Bot { id } }` は interface/union の合法な選択であり、今回の修正対象外（混同に注意）

## 発見

- **PAT 認証は機能していた**: run ログ上、1 つ目の `suggestedActors` クエリは通過し `copilot-swe-agent` を発見済み。過去の「Copilot 自動アサインは無理」の原因（既定 `GITHUB_TOKEN` 拒否）は PAT 登録（2026-06-05, PR #58）で解消済みで、残っていたブロッカーはこの構文バグのみだった
- **github-script@v7 の Node 20 deprecation 警告**: run ログに「Node.js 20 actions は 2026-06-16 以降 Node 24 強制」の警告あり。本 PR のスコープ外として未対応（別途 Issue 起票または `actions/github-script` バージョンアップで対応推奨）
