### PR TITLE
feat: insight記事を本番でインデックス可能にする（#73）

### DIFF
--- a/.claude/skills/add-insight/templates/head.html.template
+++ b/.claude/skills/add-insight/templates/head.html.template
@@ -7,7 +7,7 @@
   <title>{{TITLE}} | Stellar Careers</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <!-- og:site_name と apple-mobile-web-app-title はサイト共通のブランド表記。記事固有値への置換は不要。 -->
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="{{TITLE}}">

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ Icons use Material Symbols with `textContent` (e.g., `el.textContent = 'pause'`)
 ### insight/{id}
 - 30+ article pages at depth 2
 - Article IDs can start with `-` (e.g., `-ilnF14x`)
-- `robots: noindex, nofollow` on article pages
+- `robots: all` on article pages (indexable in production; preview deploy injects `noindex, nofollow` via `.github/workflows/preview.yml`)
 - "Go back to Insight" link uses relative path `../../insight`
 
 ### insight-case, insight-interview, insight-work

--- a/docs/insight/-ilnF14x/index.html
+++ b/docs/insight/-ilnF14x/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/0ARJimuB/index.html
+++ b/docs/insight/0ARJimuB/index.html
@@ -7,7 +7,7 @@
   <title>【AI時代のコンサルファームの選び方（2/4）】 AIはコンサルの仕事をどう変えるか—DD・資料作成・自律型AIの実例と「人が残る領域」— | Stellar Careers</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <!-- og:site_name と apple-mobile-web-app-title はサイト共通のブランド表記。記事固有値への置換は不要。 -->
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="【AI時代のコンサルファームの選び方（2/4）】 AIはコンサルの仕事をどう変えるか—DD・資料作成・自律型AIの実例と「人が残る領域」—">

--- a/docs/insight/0I3LhK1/index.html
+++ b/docs/insight/0I3LhK1/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/50buy5DB/index.html
+++ b/docs/insight/50buy5DB/index.html
@@ -7,7 +7,7 @@
   <title>【AI時代のコンサルファームの選び方（1/4）】 なぜコンサル業界はAI活用で先行するのか—事業会社との「取り組みの差」が生まれる理由— | Stellar Careers</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="【AI時代のコンサルファームの選び方（1/4）】 なぜコンサル業界はAI活用で先行するのか—事業会社との「取り組みの差」が生まれる理由—">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/insight_ai_consulting_gap_middle.webp">

--- a/docs/insight/5Rxw1qe2/index.html
+++ b/docs/insight/5Rxw1qe2/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/8SEZNhnw/index.html
+++ b/docs/insight/8SEZNhnw/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/8VZi0K92/index.html
+++ b/docs/insight/8VZi0K92/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/A73byyXx/index.html
+++ b/docs/insight/A73byyXx/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/Aq1pu6mp/index.html
+++ b/docs/insight/Aq1pu6mp/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/Ay7g4gf3/index.html
+++ b/docs/insight/Ay7g4gf3/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/B3kPqXzW/index.html
+++ b/docs/insight/B3kPqXzW/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/CyhWiTYY/index.html
+++ b/docs/insight/CyhWiTYY/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/DgVU2IHY/index.html
+++ b/docs/insight/DgVU2IHY/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/EZFRgLA5/index.html
+++ b/docs/insight/EZFRgLA5/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/FFdvC5QA/index.html
+++ b/docs/insight/FFdvC5QA/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/GLyIsS8J/index.html
+++ b/docs/insight/GLyIsS8J/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/Ht3kMnzP/index.html
+++ b/docs/insight/Ht3kMnzP/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/Hx7mK3pQ/index.html
+++ b/docs/insight/Hx7mK3pQ/index.html
@@ -7,7 +7,7 @@
   <title>【体験記】本音を"伝わる言葉"に　徹底対策で掴んだコンサル転職 | Stellar Careers</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="【体験記】本音を"伝わる言葉"に　徹底対策で掴んだコンサル転職">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/s-1200x630_v-fms_webp_454cd683-2779-474d-b262-22203b0df8ca_middle.webp">

--- a/docs/insight/I0IvMIFT/index.html
+++ b/docs/insight/I0IvMIFT/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/I5rg9N4x/index.html
+++ b/docs/insight/I5rg9N4x/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/J8lx2Bop/index.html
+++ b/docs/insight/J8lx2Bop/index.html
@@ -7,7 +7,7 @@
   <title>「マッキンゼー以外はコンサルじゃない」と洗脳される？ BCG出身者と語る、2大ファームの決定的な違い | Stellar Careers</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="「マッキンゼー以外はコンサルじゃない」と洗脳される？ BCG出身者と語る、2大ファームの決定的な違い">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/insight_mck_bcg_firm_difference_middle.webp">

--- a/docs/insight/KNPdyxKl/index.html
+++ b/docs/insight/KNPdyxKl/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/OKdvrVA0/index.html
+++ b/docs/insight/OKdvrVA0/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/OWsiXgjE/index.html
+++ b/docs/insight/OWsiXgjE/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/insight_honne_kotoba_middle.webp">

--- a/docs/insight/PeVXzZ4Q/index.html
+++ b/docs/insight/PeVXzZ4Q/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/Qh5kT2mN/index.html
+++ b/docs/insight/Qh5kT2mN/index.html
@@ -7,7 +7,7 @@
   <title>【IBM→デロイト→マッキンゼー】「これまで学んできたことを全て捨てろ」異例のキャリアを歩んだ元APが語る、ファームごとの“流儀”の違い | Stellar Careers</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="【IBM→デロイト→マッキンゼー】「これまで学んできたことを全て捨てろ」異例のキャリアを歩んだ元APが語る、ファームごとの“流儀”の違い">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/insight_ibm_deloitte_mckinsey_ryugi_middle.webp">

--- a/docs/insight/RzP2RcvL/index.html
+++ b/docs/insight/RzP2RcvL/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/SFs8TsC/index.html
+++ b/docs/insight/SFs8TsC/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/Syq-QLJD/index.html
+++ b/docs/insight/Syq-QLJD/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/WllaCZ-7/index.html
+++ b/docs/insight/WllaCZ-7/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/Y7mK2pLs/index.html
+++ b/docs/insight/Y7mK2pLs/index.html
@@ -7,7 +7,7 @@
   <title>「1ヶ月で200件インタビュー」元BCGが語る、トップファームの泥臭すぎるリアルと1日のスケジュール | Stellar Careers</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="「1ヶ月で200件インタビュー」元BCGが語る、トップファームの泥臭すぎるリアルと1日のスケジュール">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/insight_bcg_200interviews_schedule_middle.webp">

--- a/docs/insight/ZfOnLfo2/index.html
+++ b/docs/insight/ZfOnLfo2/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/dNuSBOtW/index.html
+++ b/docs/insight/dNuSBOtW/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/h7Nq2LpD/index.html
+++ b/docs/insight/h7Nq2LpD/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/j3o4DTia/index.html
+++ b/docs/insight/j3o4DTia/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/lE6yB3NV/index.html
+++ b/docs/insight/lE6yB3NV/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/lRnfUIQp/index.html
+++ b/docs/insight/lRnfUIQp/index.html
@@ -7,7 +7,7 @@
   <title>【体験記】ケース面接対策を積み重ね掴んだ戦略ファーム合格！ | Stellar Careers</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="【体験記】ケース面接対策を積み重ね掴んだ戦略ファーム合格！">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/insight_case_strategy_pass_middle.webp">

--- a/docs/insight/mfcHLG7H/index.html
+++ b/docs/insight/mfcHLG7H/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/n8mK9XvY/index.html
+++ b/docs/insight/n8mK9XvY/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/pvdzfOHV/index.html
+++ b/docs/insight/pvdzfOHV/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/tmE-tX2M/index.html
+++ b/docs/insight/tmE-tX2M/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/vePk267w/index.html
+++ b/docs/insight/vePk267w/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/wbcTHhtv/index.html
+++ b/docs/insight/wbcTHhtv/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/xUFskzV_/index.html
+++ b/docs/insight/xUFskzV_/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/yiQsUHMG/index.html
+++ b/docs/insight/yiQsUHMG/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/og-image.png">

--- a/docs/insight/zDtM3RpK/index.html
+++ b/docs/insight/zDtM3RpK/index.html
@@ -7,7 +7,7 @@
   <title>Stellar careers | コンサル特化の転職エージェント</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
   <link rel="stylesheet" href="../../assets/css/style.css" crossorigin="">
-  <meta name="robots" content="noindex, nofollow">
+  <meta name="robots" content="all">
   <meta property="og:site_name" content="Stellar careers | コンサル特化の転職エージェント">
   <meta property="og:title" content="【戦略ファーム合格者との座談会レポ】合格者が語る実践的対策のリアル">
   <meta property="og:image" content="https://stellar-careers.com/assets/images/insight_zadankai_senryaku_firm_middle.webp">


### PR DESCRIPTION
Closes #73

## 背景

本番（本repo / stellar-careers.com）の insight 記事ページ46本が `noindex, nofollow` のまま公開されており、検索エンジンのインデックス対象から外れていた。これは元の Studio.Design サイトの設定をそのまま複製したもので、本プロジェクトとして意図した SEO ポリシーではない。`docs/sitemap.xml` が記事を列挙している一方で meta が noindex という矛盾も生じていた。

## 目的

insight 記事を検索インデックス可能にし、コンテンツ担当・経営が公開記事から検索流入を得られるようにする。sitemap と meta の整合も取れ、クロール挙動が予測可能になる。

## 方針

本repo（本番）はインデックス可、preview は noindex,nofollow という出し分けが要件。調査の結果、**preview 側は既に達成済み**だった — `.github/workflows/preview.yml` が deploy 時に全 HTML へ `noindex, nofollow` を注入しており、ソース側の robots 設定に依存せず必ず noindex 化される。したがって変更は**本番ソース側のみ**で完結する。

insight 記事の robots 値は、新規の表記を増やさず**既存の通常ページ21本と同じ `content="all"`** に統一した（代替案 `index, follow` も同義だが、repo 内の規約に合わせた）。`docs/404.html` はエラーページのため `noindex` を維持（Issue で合意済み）。preview.yml / robots.txt / sitemap.xml は変更不要。

<details>
<summary>意思決定の経緯</summary>

- [採用] robots 値は `all`（既存21ページの規約に統一） ← 代替案: `index, follow`（同義）
- [採用] 404.html は noindex 維持（エラーページの index は SEO 上避ける） ← Issue 起票時にユーザ合意済み
- [採用] preview.yml は不変（既に全HTML noindex 注入済みのため変更不要）
</details>

## 設計

| 変更 | 内容 | AC |
|---|---|---|
| insight 記事46本 | `<meta name="robots" content="noindex, nofollow">` → `content="all"` | AC-1〜AC-3 |
| `docs/404.html` | 変更なし（`noindex` 維持） | AC-4 |
| `CLAUDE.md` | insight/{id} の robots 記述を実態（`all` + preview注入）に更新 | AC-6 |
| `.claude/skills/add-insight/templates/head.html.template` | 新規記事テンプレの robots を `noindex, nofollow` → `all`（add-blog テンプレと統一） | AC-8 |
| preview.yml / robots.txt / sitemap.xml | 変更なし | AC-7 |

## 受入条件

- [x] AC-1 [BUILD] `grep -rho 'name="robots" content="[^"]*"' docs/ | sort | uniq -c` → `all`=67 / `noindex`=1（404のみ）/ `noindex, nofollow`=0
- [x] AC-2 [BUILD] `grep -rln "noindex" docs/` の結果が `docs/404.html` のみ
- [x] AC-3 [UI] insight 記事の robots meta が `<meta name="robots" content="all">`
- [x] AC-4 [UI] `docs/404.html` の robots meta が `<meta name="robots" content="noindex">` のまま
- [x] AC-5 [BUILD] `npm run lint` がエラーなく完了（htmlhint: 66ファイル0エラー / stylelint: 0エラー）
- [x] AC-6 [MANUAL] CLAUDE.md の insight noindex 記述を更新
- [x] AC-7 [MANUAL] preview.yml の noindex 注入ステップ不変（preview は引き続き全ページ noindex,nofollow）
- [x] AC-8 [BUILD] `grep -rn 'noindex\|robots' .claude/skills/*/templates/` が両テンプレとも `content="all"`（新規記事が noindex で生成されない）

## 評価観点

- robots 値を `all` で統一した点（`index, follow` 派の方針があれば指摘ください。挙動は同等）
- 本番ソースから noindex を全廃したことで、preview の各ページは robots meta が1つ（注入分のみ）になりクリーン化される副次効果あり
