### PR TITLE
コメント承認のCI判定を「チェック名ごと最新1件」に絞り cancelled 残骸で誤拒否しない

### DIFF
--- a/.github/workflows/approve-by-comment.yml
+++ b/.github/workflows/approve-by-comment.yml
@@ -99,9 +99,22 @@ jobs:
             const { data: checks } = await github.rest.checks.listForRef({ owner, repo, ref, per_page: 100 });
             const { data: combined } = await github.rest.repos.getCombinedStatusForRef({ owner, repo, ref });
 
+            // 同一 SHA に同名のチェックランが複数ぶら下がることがある（preview.yml の
+            // concurrency: cancel-in-progress により、打ち切られた古いランが cancelled として
+            // 残るため）。古い残骸を失敗扱いしないよう、チェック名ごとに「最新の1件」だけを
+            // 評価対象にする。最新判定は started_at（実行中/queued のランも持つ）で行い、
+            // 同時刻は check run id（新しいほど大きい）でタイブレークする。
+            const recency = (r) => `${r.started_at ?? ''}#${String(r.id).padStart(20, '0')}`;
+            const latestByName = new Map();
+            for (const r of checks.check_runs) {
+              const cur = latestByName.get(r.name);
+              if (!cur || recency(r) > recency(cur)) latestByName.set(r.name, r);
+            }
+            const runs = [...latestByName.values()];
+
             const OK = ['success', 'neutral', 'skipped'];
-            const badRuns = checks.check_runs.filter(r => r.status === 'completed' && !OK.includes(r.conclusion));
-            const pendingRuns = checks.check_runs.filter(r => r.status !== 'completed');
+            const badRuns = runs.filter(r => r.status === 'completed' && !OK.includes(r.conclusion));
+            const pendingRuns = runs.filter(r => r.status !== 'completed');
             // コミットステータスは存在する場合のみ評価（Actions のみの構成では空になる）
             const badStatuses = combined.statuses.filter(s => s.state === 'failure' || s.state === 'error');
             const statusPending = combined.statuses.length > 0 && combined.state === 'pending';


### PR DESCRIPTION
Closes #76

## 背景

記事PRをコメントで承認→その場でマージする `approve-by-comment.yml` が、プレビューデプロイが実際には成功していてもマージを拒否することがあった。PR #68 では承認者 car-hina さんが「承認」とコメントしたのに `CI が失敗しているためマージできません🙏（deploy-preview）` と返され、最終的にエンジニアが手動マージする羽目になった。

原因は2つの正しい仕様の噛み合わせ。`preview.yml` の `concurrency: cancel-in-progress: true`（Copilot の連続イベントによる push race 防止）が古いデプロイ実行を打ち切り、同一コミットに `cancelled` の `deploy-preview` チェックランを残す。一方このワークフローのグリーン判定は、SHA に紐づく全チェックランを評価し、かつ `cancelled` を許容に含めていなかったため、残骸の `cancelled` を「失敗」と誤判定していた。

## 目的

承認者（非エンジニア）がコメントするだけで確実に公開できる状態に戻す。あわせて、同一SHAに打ち切りランが残るたび再発する潜在バグを根治し、手動マージの肩代わりをなくす。

## 方針

グリーン判定の対象を「チェック名ごとに最新の1件だけ」に絞る。最新が成功していれば、過去に concurrency で打ち切られた `cancelled` は自然に対象外になる。本物の失敗（最新ランが failure）は従来どおり弾くので、失敗の握り潰しは起きない。

<details>
<summary>設計判断：最新ランの判定キー</summary>

Issue の修正案では `completed_at` を使っていたが、実行中(pending)のランは `completed_at` が null で「最古」に倒れてしまい、「最新が実行中なら待つ」が壊れる。そこで全ランが持つ `started_at` を主キー、同時刻は check run `id`（新しいほど大きい）でタイブレークする方式に変更した。これにより completed/pending を問わず正しく最新を選べる。
</details>

## 設計

| 変更 | 内容 | AC |
|---|---|---|
| `approve-by-comment.yml` グリーン判定 | `checks.check_runs` をチェック名ごとに最新1件へ集約してから `badRuns`/`pendingRuns` を算出 | AC-1, AC-2 |

## 受入条件

- [x] [LOGIC] (AC-1) 同名 `deploy-preview` に `cancelled`(古) と `success`(新) が併存するとき `badRuns` が空＝マージ可と判定される（`/tmp/test-greengate.mjs` で確認、7/7 PASS）
- [x] [LOGIC] (AC-2) 最新の `deploy-preview` が `failure` の場合は従来どおり `badRuns` に入りマージ拒否される（失敗を握り潰さない回帰確認）
- [x] [BUILD] (AC-3) `.github/workflows/approve-by-comment.yml` が YAML パース／埋め込み github-script の構文検証を通過する
- [ ] [MANUAL][MUTATING][SIDE-EFFECT] (AC-4) 次の実記事PR（Copilot作）で approver が「承認」コメント時、同一SHAに `cancelled` な `deploy-preview` が残っていても自動マージ→本番公開される（次回記事公開時に E2E 確認。本番公開を伴うため自動実行せず人手で確認）

## 評価観点

- 「最新の1件」の判定を `started_at`＋`id` タイブレークにした点（Issue 案の `completed_at` から変更）。pending を正しく最新扱いできる一方、稀に `started_at` が同値かつ id 順が直感と異なるケースが無いか。
- 名前ごとの集約は「同名チェック＝同一チェック」という前提。本リポジトリは GitHub Actions のみ（`deploy-preview`/`cleanup-preview`）で衝突しないが、将来別アプリが同名チェックを出すと最新1件しか見なくなる点は留意。
- コミットステータス側（`getCombinedStatusForRef`）は元から `combined.state`＝最新集約済みのため未変更。

## 発見

- 特になし（本修正に閉じる）。
