### PR TITLE
feat: Copilot記事PRの最終化ワークフロー追加（Closes #N 自動付与＋Ready for review化）

### DIFF
--- a/.github/workflows/copilot-pr-finalize.yml
+++ b/.github/workflows/copilot-pr-finalize.yml
@@ -1,0 +1,126 @@
+name: Finalize Copilot article PR
+
+# Copilot coding agent が作る記事系PR（draft）を「完了」シグナルで最終化する。
+#
+# 背景: Copilot は
+#   1. Issue から作業を始めると、まず draft の WIP PR を作る。このとき本文に
+#      `Closes #<Issue>` を入れることが多く、Issue とのクローズリンクが張られる。
+#   2. 作業完了時に **本文を丸ごと書き換える**ため、`Closes #<Issue>` が消える
+#      （PR #79 で顕在化。マージしても Issue が自動クローズされず OPEN のまま残る）。
+#   3. 完了しても draft のまま残す（Ready for review にしない）ため、コメント承認
+#      フロー（approve-by-comment.yml）が「まだ draft」と判定してマージできない。
+#
+# このワークフローは Copilot の完了シグナル（review_requested）を捉えて:
+#   - 消えた `Closes #<Issue>` を本文1行目へ書き戻す（番号は WIP 時にマーカーへ退避）
+#   - draft を Ready for review に解除する
+# これにより「承認者が『承認』→ approve-by-comment がマージ→ Issue 自動クローズ」
+# まで一気通貫する。
+#
+# 注意:
+#  - `copilot_work_finished` は webhook トリガーに無いため、Copilot が完了時に出す
+#    `review_requested` を完了シグナルとして使う（人が後からレビュー依頼しても冪等）。
+#  - GitHub には「クローズリンクを直接張るAPI」が無く、本文 or コミットのクロージング
+#    キーワード経由でしか作れない。よって Copilot の最終書き換えの後に本文へ書き戻す。
+#  - PR 側には外向きのクロスリファレンスが機械リンクとして残らない（cross-reference は
+#    参照された Issue 側のタイムラインにしか出ない）。そのため対象 Issue番号は WIP 本文
+#    から拾って「非表示マーカーコメント」に退避し、完了時に回収する。
+#  - Ready 化は GITHUB_TOKEN で行う。GITHUB_TOKEN 起因のイベントは他ワークフローを
+#    再発火させない（=ループしない / preview.yml も再発火しない）が、preview は Copilot
+#    のコミット(synchronize)時に draft でもデプロイ済みのため CI は緑のまま＝実害なし。
+#  - 信頼できない入力（PR本文/タイトル）は ${{ }} 展開せず github-script 内の JS 変数
+#    として扱う（ペイロード注入回避。memory / 他ワークフローと同方針）。
+on:
+  pull_request:
+    types: [opened, review_requested, ready_for_review]
+
+jobs:
+  finalize:
+    runs-on: ubuntu-latest
+    # 記事系PR（作者が Bot=Copilot）のみ対象。エンジニア(User)のPRは触らない。
+    # （記事PRとエンジニアPRの判別は作者の user.type が最も確実＝既存方針に整合）
+    if: ${{ github.event.pull_request.user.type == 'Bot' }}
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Ensure Closes #N and mark ready for review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const action = context.payload.action;
+            const pr = context.payload.pull_request;
+            const num = pr.number;
+            // 退避用マーカー（GitHub UI 上は空表示になる HTML コメント）
+            const MARK = '<!-- copilot-pr-finalize:';
+            // クロージングキーワード（close/closes/closed, fix/fixes/fixed, resolve/...）
+            const KW = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i;
+
+            // --- opened: WIP本文から Issue番号を取り出してマーカーへ退避 ---
+            // Copilot は完了時に本文を全置換するため、番号が消える前にここで保存する。
+            if (action === 'opened') {
+              const body = pr.body || '';
+              const m = body.match(KW) || body.match(/#(\d+)/);
+              if (!m) { core.info('WIP本文に Issue 参照が無いためマーカーは作らない。'); return; }
+              const { data: comments } = await github.rest.issues.listComments({
+                owner, repo, issue_number: num, per_page: 100,
+              });
+              if (comments.some(c => (c.body || '').includes(MARK))) {
+                core.info('マーカーは既に存在。'); return;
+              }
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: num, body: `${MARK} closes=#${m[1]} -->`,
+              });
+              core.info(`マーカー作成: closes #${m[1]}`);
+              return;
+            }
+
+            // --- review_requested / ready_for_review: 最終化 ---
+            // 1) 対象 Issue番号を決める（優先順位: 既存リンク > 現本文 > マーカー）
+            const q = await github.graphql(
+              `query($o:String!,$r:String!,$n:Int!){
+                 repository(owner:$o,name:$r){
+                   pullRequest(number:$n){ closingIssuesReferences(first:1){ nodes{ number } } }
+                 }
+               }`, { o: owner, r: repo, n: num });
+            const linked = q.repository.pullRequest.closingIssuesReferences.nodes[0]?.number ?? null;
+
+            const body = pr.body || '';
+            const bm = body.match(KW);
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: num, per_page: 100,
+            });
+            const marker = comments.find(c => (c.body || '').includes(MARK));
+            const markIssue = marker ? (marker.body.match(/closes=#(\d+)/) || [])[1] : null;
+
+            const issue = linked ?? (bm ? bm[1] : null) ?? markIssue ?? null;
+
+            // 2) 本文1行目に Closes #N を書き戻す（既にリンク済みなら触らない＝冪等）
+            if (issue && !linked) {
+              const stripped = body.replace(/^\s*(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#\d+\s*\r?\n?/i, '');
+              const newBody = `Closes #${issue}\n\n${stripped.replace(/^\s+/, '')}`;
+              await github.rest.pulls.update({ owner, repo, pull_number: num, body: newBody });
+              core.info(`本文1行目に Closes #${issue} を付与。`);
+            } else if (linked) {
+              core.info(`既に #${linked} とリンク済み。本文は編集しない。`);
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: num,
+                body: '⚠️ 対象 Issue を特定できず `Closes #N` を自動付与できませんでした。お手数ですが本文1行目に手動で追記してください。',
+              });
+              core.warning('Issue番号を特定できなかった。');
+            }
+
+            // 3) draft なら Ready for review に解除
+            if (pr.draft) {
+              await github.graphql(
+                `mutation($id:ID!){ markPullRequestReadyForReview(input:{pullRequestId:$id}){ pullRequest{ number } } }`,
+                { id: pr.node_id });
+              core.info('Ready for review に変更。');
+            }
+
+            // 4) マーカーを掃除（残骸を残さない）
+            if (marker) {
+              await github.rest.issues.deleteComment({ owner, repo, comment_id: marker.id });
+            }


### PR DESCRIPTION
## 背景

Copilot coding agent が作る記事系PRで、2つの取りこぼしが起きていた（PR #79 で顕在化）。

1. **`Closes #N` が消える** — Copilot は WIP（draft）PR 作成時には本文に `Closes #78` を入れるが、**完了時に本文を丸ごと書き換える**ため消える。結果 `closingIssuesReferences` が空になり、マージしても Issue が自動クローズされず OPEN のまま残る（#67→#68 と同じ再発）。`copilot-instructions.md` のルール強化（#75 / `3904fed`）では防げなかった＝**ドキュメントは強制力がない**。
2. **draft のまま終わる** — Copilot は完了しても Ready for review にしないため、コメント承認フロー（`approve-by-comment.yml`）が「まだ draft」と判定してマージできない。

PR #79 のタイムラインが原因を示している（UTC）:
`09:25` open（WIP・本文に `Closes #78`）→ `09:35:43` rename（`[WIP]`除去＋**本文全置換で `Closes #78` 消滅**）→ `09:35:50` work_finished →`09:35:51` `review_requested`（draft のまま）。

## 目的

Copilot の完了シグナルを捉え、**消えた `Closes #N` を本文へ書き戻し**、**draft を Ready for review に解除**する。これで「承認者が『承認』→ `approve-by-comment` がマージ→ Issue 自動クローズ」まで一気通貫させ、手動マージ・手動 Ready 化の肩代わりをなくす。

## 方針・設計

新規 `.github/workflows/copilot-pr-finalize.yml`（1ファイルで両対応）。対象は作者が Bot=Copilot のPRのみ。

- **完了シグナル**: `copilot_work_finished` は webhook トリガーに無いため、Copilot が完了時に出す **`review_requested`** を使う（`ready_for_review` も拾い冪等）。
- **Issue番号の退避と回収**: PR 側には外向きのクロスリファレンスが機械リンクとして残らない（cross-reference は参照された Issue 側にしか出ない）。そこで **`opened`（WIP）時に本文から番号を拾い、非表示マーカーコメントへ退避**。完了時に「既存リンク > 現本文 > マーカー」の優先順で回収する。
- **`Closes #N` 書き戻し**: GitHub には「クローズリンクを直接張るAPI」が無く、本文/コミットのクロージングキーワード経由でしか作れない。よって Copilot の最終書き換えの**後**に本文1行目へ書き戻す。既にリンク済みなら触らない（冪等）。
- **Ready 化**: GraphQL `markPullRequestReadyForReview` を **GITHUB_TOKEN** で実行。GITHUB_TOKEN 起因イベントは他ワークフローを再発火させない＝ループしない／`preview.yml` も再発火しないが、preview は Copilot のコミット(`synchronize`)時に draft でもデプロイ済みのため **CI は緑のまま＝実害なし**（PAT は不要、むしろループ риスク回避のため不採用）。
- マーカーは完了時に削除（残骸なし）。

## 受入条件

- [x] [LOGIC] (AC-1) リンク消失・本文に番号無し・マーカーに `#78` の状態（PR #79 相当）で、本文1行目に `Closes #78` を書き戻す（`/tmp/test-finalize.mjs` 13/13 PASS）
- [x] [LOGIC] (AC-2) 既に `closingIssuesReferences` が張られている場合は本文を編集しない（冪等／二重 `Closes` を作らない）
- [x] [LOGIC] (AC-3) 手掛かりが無い場合は警告コメントを残し、誤った番号は付与しない
- [x] [BUILD] (AC-4) YAML パース／埋め込み github-script の構文検証を通過
- [ ] [MANUAL][MUTATING][SIDE-EFFECT] (AC-5) 次の実記事PR（Copilot作）で、完了時に `Closes #N` が本文へ復活し、自動で Ready for review になる（本番フローを伴うため次回記事公開時に E2E 確認）

## 評価観点

- 完了シグナルに `review_requested` を採用した点（`copilot_work_finished` の webhook が無いため）。Copilot が将来この挙動を変えた場合は再検討が必要。
- 番号回収のマーカー方式（`opened` で退避→完了時に回収・削除）。`opened` の本文に Issue 参照が無いケースのみマーカーが作られず、その場合は警告コメントで人手に委ねる。
- Ready 化を GITHUB_TOKEN で行うため `preview.yml` の `ready_for_review` は再発火しないが、preview は `synchronize` で既にデプロイ済みのため承認時の CI 判定（`approve-by-comment.yml`）に影響しない。
- 信頼できない入力（PR本文/タイトル）は `${{ }}` 展開せず github-script 内の JS 変数として扱い、注入面を作らない（既存ワークフローと同方針）。

## 発見

- PR #79 はこのワークフロー導入**前**の壊れた最終状態（マーカー無し・本文に番号無し）のため自動修復の対象外。別途手動で `Closes #78` 追記＋Ready 化を実施する（本PRとは独立）。
- `copilot-instructions.md` の `Closes #N` ルールは残す（Copilot が従えば本ワークフローは no-op になる多重防御）。
